### PR TITLE
Get fields, messages and rules by key

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -219,6 +219,67 @@ class Form implements FormInterface
         return reset($errors) ?: [];
     }
 
+
+    /**
+     * Get fields by key
+     *
+     * If no key is provided, all fields will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function fields($key = '')
+    {
+        $fields = $this->fields;
+
+        if ($key) {
+            return isset($fields[$key]) ? $fields[$key] : [];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get rules by key
+     *
+     * If no key is provided, all rules will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function rules($key = '')
+    {
+        $rules = $this->rules;
+
+        if ($key) {
+            return isset($rules[$key]) ? $rules[$key] : [];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Get messages by key
+     *
+     * If no key is provided, all messages will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function messages($key = '')
+    {
+        $messages = $this->messages;
+
+        if ($key) {
+            return isset($messages[$key]) ? $messages[$key] : [];
+        }
+
+        return $messages;
+    }
+
     /**
      * Add a single error
      *
@@ -344,65 +405,5 @@ class Form implements FormInterface
         return is_array($data)
             ? array_map('trim', $data)
             : trim($data);
-    }
-
-    /**
-     * Get fields by key
-     *
-     * If no key is provided, all fields will be returned.
-     *
-     * @param  string  $key  optional
-     *
-     * @return  array
-     */
-    public function fields($key = '')
-    {
-        $fields = $this->fields;
-
-        if ($key) {
-            return isset($fields[$key]) ? $fields[$key] : [];
-        }
-
-        return $fields;
-    }
-
-    /**
-     * Get rules by key
-     *
-     * If no key is provided, all rules will be returned.
-     *
-     * @param  string  $key  optional
-     *
-     * @return  array
-     */
-    public function rules($key = '')
-    {
-        $rules = $this->rules;
-
-        if ($key) {
-            return isset($rules[$key]) ? $rules[$key] : [];
-        }
-
-        return $rules;
-    }
-
-    /**
-     * Get messages by key
-     *
-     * If no key is provided, all messages will be returned.
-     *
-     * @param  string  $key  optional
-     *
-     * @return  array
-     */
-    public function messages($key = '')
-    {
-        $messages = $this->messages;
-
-        if ($key) {
-            return isset($messages[$key]) ? $messages[$key] : [];
-        }
-
-        return $messages;
     }
 }

--- a/src/Form.php
+++ b/src/Form.php
@@ -357,7 +357,7 @@ class Form implements FormInterface
      */
     public function fields($key = '')
     {
-        $fields = $this->fields();
+        $fields = $this->fields;
 
         if ($key) {
             return isset($fields[$key]) ? $fields[$key] : [];
@@ -377,7 +377,7 @@ class Form implements FormInterface
      */
     public function rules($key = '')
     {
-        $rules = $this->rules();
+        $rules = $this->rules;
 
         if ($key) {
             return isset($rules[$key]) ? $rules[$key] : [];
@@ -397,7 +397,7 @@ class Form implements FormInterface
      */
     public function messages($key = '')
     {
-        $messages = $this->messages();
+        $messages = $this->messages;
 
         if ($key) {
             return isset($messages[$key]) ? $messages[$key] : [];

--- a/src/Form.php
+++ b/src/Form.php
@@ -345,4 +345,64 @@ class Form implements FormInterface
             ? array_map('trim', $data)
             : trim($data);
     }
+
+    /**
+     * Get fields by key
+     *
+     * If no key is provided, all fields will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function fields($key = '')
+    {
+        $fields = $this->fields();
+
+        if ($key) {
+            return isset($fields[$key]) ? $fields[$key] : [];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get rules by key
+     *
+     * If no key is provided, all rules will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function rules($key = '')
+    {
+        $rules = $this->rules();
+
+        if ($key) {
+            return isset($rules[$key]) ? $rules[$key] : [];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Get messages by key
+     *
+     * If no key is provided, all messages will be returned.
+     *
+     * @param  string  $key  optional
+     *
+     * @return  array
+     */
+    public function messages($key = '')
+    {
+        $messages = $this->messages();
+
+        if ($key) {
+            return isset($messages[$key]) ? $messages[$key] : [];
+        }
+
+        return $messages;
+    }
 }

--- a/src/Form.php
+++ b/src/Form.php
@@ -219,7 +219,6 @@ class Form implements FormInterface
         return reset($errors) ?: [];
     }
 
-
     /**
      * Get fields by key
      *


### PR DESCRIPTION
This pull request adds getters for fields, messages and rules as discussed in https://github.com/mzur/kirby-uniform/issues/200.

I'm not sure about a few things as the existing source is ambiguous:

1. Should there be singular _and_ plural functions? E. g. `rules()` to get all rules and `rule()` to get a single rule. The data function works for singular and plural while errors have two separate functions.
2. What should be returned if a key does not exist? Following the `errors()` functions, an empty array will be returned.
3. I'm not sure how functions should be ordered inside the class and thus just appended the new ones.

Closes mzur/kirby-uniform#200.