### PR TITLE
Remove unwanted additional validation parameter

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -59,6 +59,7 @@ class Validator
             foreach ($validations as $method => $options) {
                 if (is_numeric($method)) {
                     $method = $options;
+                    $options = [];
                 }
                 $validationIndex++;
                 if ($method === 'required') {


### PR DESCRIPTION
The options need to be resetted here. Otherwise we end up with additional parameters when calling the validators.
```php
// This will fail because the date rule gets called with two parameters
// ['2021-05-20', 'date'] instead of just the expected ['2021-05-20']
new Form([
    'start_date' => [
        'rules' => ['required' ,'date']
    ]
]);
````
