### PR TITLE
Handle nested data arrays

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -402,7 +402,7 @@ class Form implements FormInterface
     protected function trimWhitespace($data)
     {
         return is_array($data)
-            ? array_map('trim', $data)
+            ? array_map([$this, 'trimWhitespace'], $data)
             : trim($data);
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -141,6 +141,15 @@ class FormTest extends TestCase
         $this->assertEquals(['value1', 'value2'], $form->data('key'));
     }
 
+    public function testTrimWhitespaceNestedArray()
+    {
+        $_POST['test'] = [[' value1'], ['value2 ']];
+        $form = new Form(['test' => []]);
+        $form->data('key', [[' value1'], ['value2 ']]);
+        $this->assertEquals([['value1'], ['value2']], $form->data('test'));
+        $this->assertEquals([['value1'], ['value2']], $form->data('key'));
+    }
+
     public function testForget()
     {
         $_POST['test'] = 'value';


### PR DESCRIPTION
If you are updating structure fields from the frontend using Kirby Uniform, content will be nested, e. g. `<input name="structure[field][]" />`. Therefore, the second level of the data array will also be an array. Currently, the form handler expects this to be a string and throws an error.