### PR TITLE
PHP 8.1: Don't pass null

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -394,7 +394,7 @@ class Form implements FormInterface
     {
         return is_array($data)
             ? array_map([$this, 'decodeField'], $data)
-            : htmlspecialchars_decode($data);
+            : htmlspecialchars_decode($data ?? '');
     }
 
     /**
@@ -408,6 +408,6 @@ class Form implements FormInterface
     {
         return is_array($data)
             ? array_map([$this, 'trimWhitespace'], $data)
-            : trim($data);
+            : trim($data ?? '');
     }
 }


### PR DESCRIPTION
Passing null throws a deprecation warning in PHP 8.1.

This PR adds the null coalescing operator to avoid passing null and the deprecation warning.