### PR TITLE
Check for CSRF Token in the Header first

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -159,7 +159,7 @@ class Form implements FormInterface
     {
         $app = App::instance();
 
-        $token = $app->request()->body()->get(self::CSRF_FIELD);
+        $token = $app->request()->csrf() ?? $app->request()->body()->get(self::CSRF_FIELD);
         if (empty($token) || csrf($token) !== true) {
             if ($app->option('debug', false) === true) {
                 throw new TokenMismatchException('The CSRF token was invalid.');

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -14,6 +14,12 @@ class FormTest extends TestCase
         $_POST['csrf_token'] = csrf();
     }
 
+    public function tearDown(): void
+    {
+        unset($_POST['csrf_token']);
+        unset($_SERVER['HTTP_X_CSRF']);
+    }
+
     public function testData()
     {
         $_POST['test'] = 'value';
@@ -211,10 +217,19 @@ class FormTest extends TestCase
         $form->validates();
     }
 
-    public function testValidateCsrfSuccess()
+    public function testValidatePostCsrfSuccess()
     {
+        unset($_POST['csrf_token']);
         $form = new Form;
         $_POST['csrf_token'] = csrf();
+        $this->assertTrue($form->validates());
+    }
+
+    public function testValidateHeaderCsrfSuccess()
+    {
+        unset($_POST['csrf_token']);
+        $form = new Form;
+        $_SERVER['HTTP_X_CSRF'] = csrf();
         $this->assertTrue($form->validates());
     }
 


### PR DESCRIPTION
Since the CSRF Token can be delivered via http header or get param (https://getkirby.com/docs/reference/objects/http/request/csrf) this should be taken into account while validating. This might solve some problems with handling upload forms with ajax as well.