### PR TITLE
Update composer.json to support Kirby composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,10 @@
     "description": "A form helper for Kirby-based websites, using the Post/Redirect/Get pattern.",
     "type": "library",
     "license": "MIT",
-    "keywords": ["kirby", "form"],
+    "keywords": [
+        "kirby",
+        "form"
+    ],
     "authors": [
         {
             "name": "Steve Jamesson",
@@ -15,7 +18,8 @@
         }
     ],
     "require": {
-        "mzur/kirby-flash": "^2.0"
+        "mzur/kirby-flash": "^2.0",
+        "getkirby/composer-installer": "^1.2"
     },
     "autoload": {
         "psr-4": {
@@ -34,8 +38,5 @@
         "phpunit/phpunit": "^9.0",
         "mzur/kirby-defuse-session": "^1.0",
         "getkirby/cms": "^3.0"
-    },
-    "extra": {
-        "kirby-cms-path": "vendor/getkirby/kirby"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mzur/kirby-form",
     "description": "A form helper for Kirby-based websites, using the Post/Redirect/Get pattern.",
-    "type": "library",
+    "type": "kirby-plugin",
     "license": "MIT",
     "keywords": [
         "kirby",


### PR DESCRIPTION
The [Kirby plugin docs](https://getkirby.com/docs/guide/plugins/plugin-setup-basic#the-composer-json) now recommend using `getkirby/composer-installer` and `type: kirby-plugin` to ensure the plugin is set up in the expected Kirby path.

(Prior to this change, `kirby-form` was not installed in the Kirby plugins directory, which broke my editor's PHP typing for it.)

(Note: this issue also affects [mzur/kirby-uniform](https://github.com/mzur/kirby-uniform), but I saw you were vendoring dependencies and wasn't sure if you wanted to move to composer-required dependencies...)