### PR TITLE
Add support for fallback value other than '' in $form->old()

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -140,13 +140,14 @@ class Form implements FormInterface
      * Get the data that was flashed to the session
      *
      * @param  string  $key
+     * @param  mixed   $default
      * @return  mixed
      */
-    public function old($key)
+    public function old($key, $default = '')
     {
         $data = $this->flash->get(self::FLASH_KEY_DATA, []);
 
-        return isset($data[$key]) ? $this->encodeField($data[$key]) : '';
+        return isset($data[$key]) ? $this->encodeField($data[$key]) : $default;
     }
 
     /**

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -40,6 +40,8 @@ class FormTest extends TestCase
         $_POST['test'] = '<value>';
         $form = new Form(['test' => ['rules' => ['num']]]);
         $this->assertEmpty($form->old('test'));
+        $this->assertEquals(null, $form->old('test', null));
+        $this->assertEquals(0, $form->old('test', 0));
         $form->validates();
         $this->assertEquals('&lt;value&gt;', $form->old('test'));
     }


### PR DESCRIPTION
Allows you to define your own fallback value if the field wasn't found in the flash, like so:

```php
$form->old('field', null);
$form->old('field', 0);
$form->old('field', 'whatever');
```

the reason for this: if you're building your input programmatically, like so:

```php
echo Html::tag('input', '', ['value'=>$form->old('field')]);
```

Kirby now throws a depreciation warning about passing an empty string as the value, and requires a `null` to properly decide to omit the attribute.

Currently the best option is to use `$form->old('field') ?: null` (as I do now), but I think being more explicit about the default value would be better.

